### PR TITLE
Add Drag and Drop ability to cards in PlayerSelectionScreen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -803,6 +803,22 @@
         }
       }
     },
+    "@babel/runtime-corejs2": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.3.1.tgz",
+      "integrity": "sha512-YpO13776h3e6Wy8dl2J8T9Qwlvopr+b4trCEhHE+yek6yIqV8sx6g3KozdHMbXeBpjosbPi+Ii5Z7X9oXFHUKA==",
+      "requires": {
+        "core-js": "^2.5.7",
+        "regenerator-runtime": "^0.12.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+        }
+      }
+    },
     "@babel/template": {
       "version": "7.2.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
@@ -3182,6 +3198,14 @@
         "public-encrypt": "^4.0.0",
         "randombytes": "^2.0.0",
         "randomfill": "^1.0.3"
+      }
+    },
+    "css-box-model": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.1.1.tgz",
+      "integrity": "sha512-ZxbuLFeAPEDb0wPbGfT7783Vb00MVAkvOlMKwr0kA2PD5EGxk6P3MAhedvVuyVJCWb54bb+6HQ7pdPYENf8AZw==",
+      "requires": {
+        "tiny-invariant": "^1.0.3"
       }
     },
     "css-color-names": {
@@ -8524,6 +8548,11 @@
         "mimic-fn": "^1.0.0"
       }
     },
+    "memoize-one": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.1.0.tgz",
+      "integrity": "sha512-2GApq0yI/b22J2j9rhbrAlsHb0Qcz+7yWxeLG8h+95sl1XPUgeLimQSOdur4Vw7cUhrBHwaUZxWFZueojqNRzA=="
+    },
     "memory-fs": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
@@ -13060,6 +13089,11 @@
         "performance-now": "^2.1.0"
       }
     },
+    "raf-schd": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.0.tgz",
+      "integrity": "sha512-m7zq0JkIrECzw9mO5Zcq6jN4KayE34yoIS9hJoiZNXyOAT06PPA8PrR+WtJIeFW09YjUfNkMMN9lrmAt6BURCA=="
+    },
     "randomatic": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
@@ -13153,6 +13187,21 @@
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
           "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
         }
+      }
+    },
+    "react-beautiful-dnd": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/react-beautiful-dnd/-/react-beautiful-dnd-10.0.3.tgz",
+      "integrity": "sha512-A6N50lv2RnXH9kNRKy+HYcQYOgRmgQRdn8qaKTTb4sYzX0H/4UhEYuOnh5PQB8i66bvCpfkxxD9El/OjgbtpPw==",
+      "requires": {
+        "@babel/runtime-corejs2": "^7.2.0",
+        "css-box-model": "^1.1.1",
+        "memoize-one": "^4.1.0",
+        "prop-types": "^15.6.1",
+        "raf-schd": "^4.0.0",
+        "react-redux": "^5.0.7",
+        "redux": "^4.0.1",
+        "tiny-invariant": "^1.0.3"
       }
     },
     "react-dev-utils": {
@@ -13304,6 +13353,40 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-5.1.2.tgz",
       "integrity": "sha512-7kEBKwU9R8fKnZJBRa5RSIfay4KJwnYvKB6gODGicUmDSAhQJ7Tdnll5S0RLtYrzRfMVXlqYw61rzrSpP4ThLQ=="
+    },
+    "react-is": {
+      "version": "16.7.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.7.0.tgz",
+      "integrity": "sha512-Z0VRQdF4NPDoI0tsXVMLkJLiwEBa+RP66g0xDHxgxysxSoCUccSten4RTF/UFvZF1dZvZ9Zu1sx+MDXwcOR34g=="
+    },
+    "react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-redux": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.1.1.tgz",
+      "integrity": "sha512-LE7Ned+cv5qe7tMV5BPYkGQ5Lpg8gzgItK07c67yHvJ8t0iaD9kPFPAli/mYkiyJYrs2pJgExR2ZgsGqlrOApg==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "hoist-non-react-statics": "^3.1.0",
+        "invariant": "^2.2.4",
+        "loose-envify": "^1.1.0",
+        "prop-types": "^15.6.1",
+        "react-is": "^16.6.0",
+        "react-lifecycles-compat": "^3.0.0"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.2.1.tgz",
+          "integrity": "sha512-TFsu3TV3YLY+zFTZDrN8L2DTFanObwmBLpWvJs1qfUuEQ5bTAdFcwfx2T/bsCXfM9QHSLvjfP+nihEl0yvozxw==",
+          "requires": {
+            "react-is": "^16.3.2"
+          }
+        }
+      }
     },
     "react-router": {
       "version": "4.3.1",
@@ -13736,6 +13819,15 @@
       "integrity": "sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==",
       "requires": {
         "minimatch": "3.0.4"
+      }
+    },
+    "redux": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.1.tgz",
+      "integrity": "sha512-R7bAtSkk7nY6O/OYMVR9RiBI+XghjF9rlbl5806HJbQph0LJVHZrU5oaO4q70eUKiqMRqm4y07KLTlMZ2BlVmg==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "symbol-observable": "^1.2.0"
       }
     },
     "regenerate": {
@@ -15305,6 +15397,11 @@
         "util.promisify": "~1.0.0"
       }
     },
+    "symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+    },
     "symbol-tree": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
@@ -15490,6 +15587,11 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
+    },
+    "tiny-invariant": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.3.tgz",
+      "integrity": "sha512-ytQx8T4DL8PjlX53yYzcIC0WhIZbpR0p1qcYjw2pHu3w6UtgWwFJQ/02cnhOnBBhlFx/edUIfcagCaQSe3KMWg=="
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "lodash": "^4.17.11",
     "path-to-regexp": "^3.0.0",
     "react": "^16.7.0",
+    "react-beautiful-dnd": "^10.0.3",
+    "react-dnd": "^7.0.2",
     "react-dom": "^16.7.0",
     "react-router-dom": "^4.3.1",
     "react-scripts": "2.1.3"

--- a/src/Screens/PlayerSelectionScreen/PlayerSelectionScreen.jsx
+++ b/src/Screens/PlayerSelectionScreen/PlayerSelectionScreen.jsx
@@ -12,7 +12,6 @@ import Footer from "../../components/Footer/Footer"
 import Status from "../../components/Status/Status"
 
 // Import Helper Libraries
-import _ from "lodash"
 import { DragDropContext } from "react-beautiful-dnd";
 
 class PlayerSelectionScreen extends React.Component {
@@ -104,54 +103,32 @@ class PlayerSelectionScreen extends React.Component {
         }
       ]
     }
-
-    this.chooseCard = this.chooseCard.bind(this);
   }
 
   componentDidMount() {
     console.log("PlayerSelectionScreen: componentDidMount()")
-    // let timerIntervalID = setInterval(() => {
-    //   if (this.state.timeLeft < 1) {
-    //     // this.animateWinner()
-    //     this.setState({ timeLeft: 60 });
-    //   }
-    //   // else if(this.state.timeLeft % 3 === 0) {
-    //   //   this.animateWinner();
-    //   // }
-    //   // else if(this.state.timeLeft % 7 === 0) {
-    //   //   // this.restoreScreen();
-    //   // }
-    //   this.setState((state, props) => ({
-    //     timeLeft: state.timeLeft - 1
-    //   }));
-    // }, 1000);
+    let timerIntervalID = setInterval(() => {
+      if (this.state.timeLeft < 1) {
+        // this.animateWinner()
+        this.setState({ timeLeft: 60 });
+      }
+      // else if(this.state.timeLeft % 3 === 0) {
+      //   this.animateWinner();
+      // }
+      // else if(this.state.timeLeft % 7 === 0) {
+      //   // this.restoreScreen();
+      // }
+      this.setState((state, props) => ({
+        timeLeft: state.timeLeft - 1
+      }));
+    }, 1000);
 
-    // this.setState({ timerIntervalID });
+    this.setState({ timerIntervalID });
   }
 
   componentWillUnmount() {
     console.log("PlayerSelectionScreen: componentWillUnmount()")
     clearInterval(this.state.timerIntervalID);
-  }
-
-  // Choose the card with given ID to be in the placeholder (DropcCardSpace),
-  // if a card is already choosen and we chooseCard again, then the card is swapped.
-  chooseCard(id) {
-    console.log(`${id} was clicked!`);
-
-    let newCards = this.state.cards;
-    if (this.state.playerChoice) {
-      newCards.unshift(this.state.playerChoice)
-    }
-    let newPlayerChoice = _.find(newCards, card => { return card.id === id });
-    _.remove(newCards, (card) => {
-      return card.id === id
-    });
-
-    this.setState({
-      playerChoice: newPlayerChoice,
-      cards: newCards
-    });
   }
 
   animateWinner() {
@@ -167,9 +144,10 @@ class PlayerSelectionScreen extends React.Component {
   }
 
 
+  // choosing card logic (drag-and-drop)
   onDragEnd = result => {
     const { destination, source } = result;
-    console.log(result);
+    // console.log(result);
 
     if (!destination) {
       return;
@@ -181,15 +159,33 @@ class PlayerSelectionScreen extends React.Component {
     }
 
     if (source.droppableId === destination.droppableId) {
-      // shift cards in correct order @ CardCarousel
+      // shift/move cards in correct order @ CardCarousel
       console.log("swapping!")
-      let newCards = Array.from(this.state.cards);
+      let newCards = [...this.state.cards];
       newCards.splice(source.index, 1);
       newCards.splice(destination.index, 0, this.state.cards[source.index])
       this.setState({ cards: newCards })
     }
-    else if (source.droppableId === "bottom" && destination.droppableId === "top") {
-      // TODO: swapping from current cards, into placeholder
+    else if (source.droppableId === "bottom" && destination.droppableId === "top" && this.state.playerChoice == null) {
+      console.log("choose a card!")
+      let newCards = [...this.state.cards];
+      // remove source card from cards
+      // TODO: should swap if already choosen a card (maybe, or are they locked in?...)
+      newCards.splice(source.index, 1);
+      this.setState({
+        playerChoice: this.state.cards[source.index],
+        cards: newCards
+      })
+    }
+    else if (source.droppableId === "top" && destination.droppableId === "bottom") {
+      // returned a card to the deck
+      console.log("returned a card to the deck!")
+      let newCards = [...this.state.cards]
+      newCards.splice(destination.index, 0, this.state.playerChoice)
+      this.setState({
+        cards: newCards,
+        playerChoice: null
+      });
     }
   }
 

--- a/src/Screens/PlayerSelectionScreen/PlayerSelectionScreen.jsx
+++ b/src/Screens/PlayerSelectionScreen/PlayerSelectionScreen.jsx
@@ -18,13 +18,37 @@ class PlayerSelectionScreen extends React.Component {
   constructor(props) {
     super(props);
     
+    // populate the whole state via the socket/backend api
+
+    // if player
+    // 1 --> 5 --> 6
+    // if judge
+    // 3 --> 4 --> 6
+
+    // roundType can be:
+    // 1. player-selecting -- done
+    //  This means its the players turn and they are selecting a car 
+    // 3. judge-waiting
+    //  Its the judges turn and they are waiting for the other players to turn in their cards (screen 7 in figma)
+    // 4. judge-selecting
+    //  This occurs when the round is over, and the judge goes through each card, 1 by 1 to select the funiest. The cards are hidden and
+    // become revealed once the judge clicks on the white card (screen 8 on figma)
+    // 5. player-viewing
+    // This occurs simultaneously with (4), only the player is viewing and cannot do anything. Options are revealed whenever
+    // the judge in (4) selects to reveal the cards. (screen 7 on figma)
+    // 6. Winner-choosen
+    // Everyone sees the same page, a winner is choose. Tapping anywhere to continue takes you to the next screen
+    // Once at least half of the players have joined, the timer begins.
     this.state = {
+      roundType: "player-selecting", // player-selecting | player-viewing | viewing-winner | 
+      roundRole: "player", // player | judge
+      roundJudge: "Yusuf",
       playerChoice: null,
       timeLeft: 60,
       QCard: {
         cardType: "Q",
         text: "TSA guidelines now prohibit _ on airplanes.",
-        id: 0
+        id: 25
       },
       cards: [
         {
@@ -85,11 +109,10 @@ class PlayerSelectionScreen extends React.Component {
 
   componentDidMount() {
     console.log("PlayerSelectionScreen: componentDidMount()")
-    // timer counts down by 1 second then alerts that time is up!
     let intervalID = setInterval(() => {
       if(this.state.timeLeft < 1) {
-        this.setState({timeLeft: 60});
         alert("times up!")
+        this.setState({timeLeft: 60});
       }
       else {
         this.setState((state, props) => ({
@@ -131,6 +154,14 @@ class PlayerSelectionScreen extends React.Component {
       playerChoice: newPlayerChoice,
       cards: newCards
     });
+  }
+
+  animateWinner() {
+    
+  }
+
+  restoreScreen() {
+    
   }
   
   render() {

--- a/src/Screens/PlayerSelectionScreen/PlayerSelectionScreen.jsx
+++ b/src/Screens/PlayerSelectionScreen/PlayerSelectionScreen.jsx
@@ -13,6 +13,7 @@ import Status from "../../components/Status/Status"
 
 // Import Helper Libraries
 import _ from "lodash"
+import { DragDropContext } from "react-beautiful-dnd";
 
 class PlayerSelectionScreen extends React.Component {
   constructor(props) {
@@ -109,23 +110,23 @@ class PlayerSelectionScreen extends React.Component {
 
   componentDidMount() {
     console.log("PlayerSelectionScreen: componentDidMount()")
-    let timerIntervalID = setInterval(() => {
-      if (this.state.timeLeft < 1) {
-        // this.animateWinner()
-        this.setState({ timeLeft: 60 });
-      }
-      // else if(this.state.timeLeft % 3 === 0) {
-      //   this.animateWinner();
-      // }
-      // else if(this.state.timeLeft % 7 === 0) {
-      //   // this.restoreScreen();
-      // }
-      this.setState((state, props) => ({
-        timeLeft: state.timeLeft - 1
-      }));
-    }, 1000);
+    // let timerIntervalID = setInterval(() => {
+    //   if (this.state.timeLeft < 1) {
+    //     // this.animateWinner()
+    //     this.setState({ timeLeft: 60 });
+    //   }
+    //   // else if(this.state.timeLeft % 3 === 0) {
+    //   //   this.animateWinner();
+    //   // }
+    //   // else if(this.state.timeLeft % 7 === 0) {
+    //   //   // this.restoreScreen();
+    //   // }
+    //   this.setState((state, props) => ({
+    //     timeLeft: state.timeLeft - 1
+    //   }));
+    // }, 1000);
 
-    this.setState({ timerIntervalID });
+    // this.setState({ timerIntervalID });
   }
 
   componentWillUnmount() {
@@ -165,21 +166,50 @@ class PlayerSelectionScreen extends React.Component {
     this.setState({ roundType: "player-selecting" });
   }
 
+
+  onDragEnd = result => {
+    const { destination, source } = result;
+    console.log(result);
+
+    if (!destination) {
+      return;
+    }
+    if (destination.droppableId === source.droppableId &&
+      destination.index === source.index
+    ) {
+      return;
+    }
+
+    if (source.droppableId === destination.droppableId) {
+      // shift cards in correct order @ CardCarousel
+      console.log("swapping!")
+      let newCards = Array.from(this.state.cards);
+      newCards.splice(source.index, 1);
+      newCards.splice(destination.index, 0, this.state.cards[source.index])
+      this.setState({ cards: newCards })
+    }
+    else if (source.droppableId === "bottom" && destination.droppableId === "top") {
+      // TODO: swapping from current cards, into placeholder
+    }
+  }
+
   render() {
     return (
       <Screen>
-        <Top>
-          <HeaderMenu text="Yusuf is the Judge" timeLeft={this.state.timeLeft} />
-          <DropCardSpace QCard={this.state.QCard} playerChoice={this.state.playerChoice} status="Waiting for 2/5 Players" />
-        </Top>
-        <Bottom>
-          <Status message="Choose 1 Card" />
-          <CardCarousel cards={this.state.cards} onClick={this.chooseCard} />
-          <Footer>
-            Invite your friends with Party Code: {this.props.match.params.partyCode}
-          </Footer>
-        </Bottom>
-      </Screen>
+        <DragDropContext onDragEnd={this.onDragEnd} >
+          <Top>
+            <HeaderMenu text="Yusuf is the Judge" timeLeft={this.state.timeLeft} />
+            <DropCardSpace QCard={this.state.QCard} playerChoice={this.state.playerChoice} status="Waiting for 2/5 Players" />
+          </Top>
+          <Bottom>
+            <Status message="Choose 1 Card" />
+            <CardCarousel cards={this.state.cards} />
+            <Footer>
+              Invite your friends with Party Code: {this.props.match.params.partyCode}
+            </Footer>
+          </Bottom >
+        </DragDropContext >
+      </Screen >
     );
   }
 }

--- a/src/Screens/PlayerSelectionScreen/PlayerSelectionScreen.jsx
+++ b/src/Screens/PlayerSelectionScreen/PlayerSelectionScreen.jsx
@@ -17,7 +17,7 @@ import _ from "lodash"
 class PlayerSelectionScreen extends React.Component {
   constructor(props) {
     super(props);
-    
+
     // populate the whole state via the socket/backend api
 
     // if player
@@ -41,7 +41,7 @@ class PlayerSelectionScreen extends React.Component {
     // Once at least half of the players have joined, the timer begins.
     this.state = {
       roundType: "player-selecting", // player-selecting | player-viewing | viewing-winner | 
-      roundRole: "player", // player | judge
+      roundPlayerRole: "player", // player | judge
       roundJudge: "Yusuf",
       playerChoice: null,
       timeLeft: 60,
@@ -109,46 +109,43 @@ class PlayerSelectionScreen extends React.Component {
 
   componentDidMount() {
     console.log("PlayerSelectionScreen: componentDidMount()")
-    let intervalID = setInterval(() => {
-      if(this.state.timeLeft < 1) {
-        alert("times up!")
-        this.setState({timeLeft: 60});
+    let timerIntervalID = setInterval(() => {
+      if (this.state.timeLeft < 1) {
+        // this.animateWinner()
+        this.setState({ timeLeft: 60 });
       }
-      else {
-        this.setState((state, props) => ({
-          timeLeft: state.timeLeft - 1
-        }));
-      }
+      // else if(this.state.timeLeft % 3 === 0) {
+      //   this.animateWinner();
+      // }
+      // else if(this.state.timeLeft % 7 === 0) {
+      //   // this.restoreScreen();
+      // }
+      this.setState((state, props) => ({
+        timeLeft: state.timeLeft - 1
+      }));
     }, 1000);
 
-    this.setState({intervalID});
+    this.setState({ timerIntervalID });
   }
 
   componentWillUnmount() {
     console.log("PlayerSelectionScreen: componentWillUnmount()")
-    clearInterval(this.state.intervalID);
+    clearInterval(this.state.timerIntervalID);
   }
 
   // Choose the card with given ID to be in the placeholder (DropcCardSpace),
   // if a card is already choosen and we chooseCard again, then the card is swapped.
   chooseCard(id) {
     console.log(`${id} was clicked!`);
-    
+
     let newCards = this.state.cards;
-    if(this.state.playerChoice) {
+    if (this.state.playerChoice) {
       newCards.unshift(this.state.playerChoice)
     }
-    // console.log(`newCards = ${newCards.map(c => c.id)}`)
-
-    // remove the card we just selected
     let newPlayerChoice = _.find(newCards, card => { return card.id === id });
-    // console.log(`new playerChoice = ${newPlayerChoice}`)
-    
     _.remove(newCards, (card) => {
       return card.id === id
     });
-    // console.log(`removing card with id: ${id}`)
-    // console.log(`newCards after removal = ${newCards.map(c => c.id)}`)
 
     this.setState({
       playerChoice: newPlayerChoice,
@@ -157,13 +154,17 @@ class PlayerSelectionScreen extends React.Component {
   }
 
   animateWinner() {
-    
+    console.log("Showing winner");
+    document.getElementById('top').style.height = '100%';
+    this.setState({ roundType: "viewing-winner" });
   }
 
   restoreScreen() {
-    
+    console.log("restoring screen");
+    document.getElementById('top').style.height = '55%';
+    this.setState({ roundType: "player-selecting" });
   }
-  
+
   render() {
     return (
       <Screen>
@@ -173,7 +174,7 @@ class PlayerSelectionScreen extends React.Component {
         </Top>
         <Bottom>
           <Status message="Choose 1 Card" />
-          <CardCarousel cards={this.state.cards} onClick={this.chooseCard}/>
+          <CardCarousel cards={this.state.cards} onClick={this.chooseCard} />
           <Footer>
             Invite your friends with Party Code: {this.props.match.params.partyCode}
           </Footer>

--- a/src/components/Bottom/Bottom.css
+++ b/src/components/Bottom/Bottom.css
@@ -1,16 +1,21 @@
 /* Bottom Half */
 .bottom {
-  width: 100%;
   height: 45%;
   z-index: 1;
   background-color: white;
   position: relative;
-}
 
-.inner {
+  /* inner */
   padding: 0px 15px;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  height: 100%;
+
+  /* transition */
+  transition: 1s;
 }
+/* 
+.inner {
+  
+  height: 100%;
+} */

--- a/src/components/Bottom/Bottom.jsx
+++ b/src/components/Bottom/Bottom.jsx
@@ -3,10 +3,8 @@ import "./Bottom.css"
 
 function Bottom(props) {
   return (
-    <div className="bottom">
-      <div className="inner">
-        {props.children}
-      </div>
+    <div className="bottom" id="bottom">
+      {props.children}
     </div>
   );
 }

--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -1,6 +1,9 @@
 import React from 'react'
 import "./Card.css"
-import {Link} from "react-router-dom";
+
+// external imports
+import { Link } from "react-router-dom";
+import { Draggable } from "react-beautiful-dnd"
 
 function Card(props) {
   if (props.cardType === "Q") {
@@ -10,7 +13,7 @@ function Card(props) {
           <p>{props.text.replace("_", "__________")}</p>
         </div>
         {
-          props.status && 
+          props.status &&
           <div className={`status ${props.className}`}>
             <span>{props.status}</span>
           </div>
@@ -21,7 +24,7 @@ function Card(props) {
   else if (props.cardType === "Title") {
     return (
       <div className={`card Title ${props.className}`}>
-        <h3>Cards</h3> 
+        <h3>Cards</h3>
         <h3>Against</h3>
         <h3>Humanity</h3>
       </div>
@@ -50,9 +53,20 @@ function Card(props) {
   }
   else {
     return (
-      <div className={`card A ${props.className}`} onClick={props.onClick && ((e) => props.onClick(props.id))}>
-        <p>{props.text}</p>
-      </div>
+      <Draggable draggableId={`${props.id}`} index={props.index}>
+        {
+          (provider) => (
+            <div
+              className={`card A ${props.className}`}
+              {...provider.draggableProps}
+              {...provider.dragHandleProps}
+              ref={provider.innerRef}
+            >
+              <p>{props.text}</p>
+            </div>
+          )
+        }
+      </Draggable>
     );
   }
 }

--- a/src/components/CardCarousel/CardCarousel.jsx
+++ b/src/components/CardCarousel/CardCarousel.jsx
@@ -2,13 +2,24 @@ import React from 'react'
 import "./CardCarousel.css"
 import Card from "../Card/Card"
 
+import { Droppable } from "react-beautiful-dnd";
+
 function CardCarousel(props) {
   return (
-    <div className="scrolling-wrapper">
+    <Droppable droppableId={'bottom'} direction="horizontal">
       {
-        props.cards.map((card) => <Card {...card} key={card.id} onClick={props.onClick}/>)
+        (provider) => (
+          <div
+            ref={provider.innerRef}
+            {...provider.droppableProps}
+            className="scrolling-wrapper"
+          >
+            {props.cards.map((card, index) => <Card {...card} key={card.id} index={index} />)}
+            {provider.placeholder}
+          </div >
+        )
       }
-    </div>
+    </Droppable>
   );
 }
 

--- a/src/components/DropCardSpace/DropCardSpace.jsx
+++ b/src/components/DropCardSpace/DropCardSpace.jsx
@@ -1,12 +1,26 @@
 import React from 'react'
 import Card from "../Card/Card"
 import "./DropCardSpace.css"
+import { Droppable } from "react-beautiful-dnd";
 
 function DropCardSpace(props) {
   return (
     <div className="drop-space">
-      <Card {...props.QCard} status={props.status}/>
-      {(props.playerChoice && <Card {...props.playerChoice}/>) || <Card cardType= "placeholder"/>}
+      <Card {...props.QCard} status={props.status} />
+      <Droppable droppableId='top' direction="horizontal">
+        {
+          (provider) => (
+            <div
+              className=""
+              ref={provider.innerRef}
+              {...provider.droppableProps}
+            >
+              {(props.playerChoice && <Card {...props.playerChoice} index={0} />) || <Card cardType="placeholder" />}
+              {provider.placeholder}
+            </div>
+          )
+        }
+      </Droppable>
     </div>
   );
 }

--- a/src/components/Footer/Footer.css
+++ b/src/components/Footer/Footer.css
@@ -3,6 +3,5 @@
   text-align: center; 
   font-size: 15px;
   text-align: center; 
-  margin-bottom: 10px;
-  /* line-height: 10px; */
+  margin-bottom: 5px;
 }

--- a/src/components/Top/Top.css
+++ b/src/components/Top/Top.css
@@ -4,4 +4,6 @@
   background-color: #D8D8D8;
   z-index: 0;
   overflow: hidden;
+
+  transition: 1s;
 }

--- a/src/components/Top/Top.jsx
+++ b/src/components/Top/Top.jsx
@@ -3,7 +3,7 @@ import "./Top.css"
 
 function Top(props) {
   return (
-    <div className="top">
+    <div className="top" id="top">
       {props.children}
   </div>
   );


### PR DESCRIPTION
This PR brings improvements in the User Experience by enable drag and drop ability for the cards in the main gameplay (PlayerSelectionScreen).

With the great `react-beautiful-dnd` npm package, we can now drag and drop cards to shuffle them or organize them inside of our `<CardCarousel/>` component. This is a great added benefit, because it makes our web app feel natural and like a mobile app. Before this, we had only the ability to click on cards and have them appear inside of the <Drop Card Here> placeholder in the `<DropCardSpace>`.

Another small improvement in this PR is the framework for animations between screens. in the `animateWinner()` function, we animate the screen by increasing the height of the `<Top>`, thus adding the effect of a transition. After the animation is over, we can restore the screen with the `restoreScreen()` function. I am still not 100% certain what the best way to do animations is, but this seems like a good start.