### PR TITLE
Configure CircleCI config.yml to automatically build on changes to master and push docker images to dockerhub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,14 +62,14 @@ workflows:
       - build:
           filters:
             branches:
-              only: cicd
+              only: master
       - publish-latest:
           context: Master Production Context
           requires:
             - build
           filters:
             branches:
-              only: cicd
+              only: master
   build-tags:
     jobs:
       - build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,10 @@ jobs:
           name: Publish Docker Image to Docker Hub
           command: |
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+            IMAGE_TAG="0.0.${CIRCLE_BUILD_NUM}"
+            docker tag $IMAGE_NAME:latest $IMAGE_NAME:$IMAGE_TAG
             docker push $IMAGE_NAME:latest
+            docker push $IMAGE_NAME:$IMAGE_TAG
   publish-tag:
         executor: docker-publisher
         steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ workflows:
             branches:
               only: cicd
       - publish-latest:
+          context: Master Production Context
           requires:
             - build
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,13 @@
 version: 2
 executors:
-  docker-publisher:
+  docker:
     environment:
       IMAGE_NAME: yusufameri/cah
     docker:
       - image: circleci/buildpack-deps:stretch
 jobs:
   build:
-    executor: docker-publisher
+    executor: docker
     steps:
       - checkout
       - setup_remote_docker
@@ -22,7 +22,7 @@ jobs:
           paths:
             - ./image.tar
   publish-latest:
-    executor: docker-publisher
+    executor: docker
     steps:
       - attach_workspace:
           at: /tmp/workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,23 +1,35 @@
 version: 2
-jobs:
-  build:
+executors:
+  docker-publisher:
     environment:
       IMAGE_NAME: yusufameri/cah
     docker:
       - image: circleci/buildpack-deps:stretch
+jobs:
+  build:
+    executor: docker-publisher
     steps:
       - checkout
       - setup_remote_docker
       - run:
           name: Build Docker image
           command: docker build -t $IMAGE_NAME:latest .
+      - run:
+          name: Archive Docker image
+          command: docker save -o image.tar $IMAGE_NAME
+      - persist_to_workspace:
+          root: .
+          paths:
+            - ./image.tar
   publish-latest:
-    environment:
-      IMAGE_NAME: yusufameri/cah
-    docker:
-      - image: circleci/buildpack-deps:stretch
+    executor: docker-publisher
     steps:
+      - attach_workspace:
+          at: /tmp/workspace
       - setup_remote_docker
+      - run:
+          name: Load archived Docker image
+          command: docker load -i /tmp/workspace/image.tar
       - run:
           name: Publish Docker Image to Docker Hub
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,13 @@
-version: 2
+version: 2.1
 executors:
-  docker:
+  docker-publisher:
     environment:
       IMAGE_NAME: yusufameri/cah
     docker:
       - image: circleci/buildpack-deps:stretch
 jobs:
   build:
-    executor: docker
+    executor: docker-publisher
     steps:
       - checkout
       - setup_remote_docker
@@ -22,7 +22,7 @@ jobs:
           paths:
             - ./image.tar
   publish-latest:
-    executor: docker
+    executor: docker-publisher
     steps:
       - attach_workspace:
           at: /tmp/workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,19 +67,19 @@ workflows:
           filters:
             branches:
               only: cicd
-    build-tags:
-      jobs:
-        - build:
-            filters:
-              tags:
-                only: /^v.*/
-              branches:
-                ignore: /.*/
-        - publish-tag:
-            requires:
-              - build
-            filters:
-              tags:
-                only: /^v.*/
-              branches:
-                ignore: /.*/
+  build-tags:
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+      - publish-tag:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,21 +1,39 @@
 version: 2
-jobs:
-  build:
-    environment:
-      IMAGE_NAME: yusufameri/cah
-    docker:
-      - image: circleci/buildpack-deps:stretch
-    steps:
-      - checkout
-      - setup_remote_docker
-      - run:
-          name: Build Docker image
-          command: docker build -t $IMAGE_NAME:latest .
-workflows:
-  version: 2
-  build-master:
     jobs:
-      - build:
-          filters:
-            branches:
-              only: cicd
+      build:
+        environment:
+          IMAGE_NAME: yusufameri/cah
+        docker:
+          - image: circleci/buildpack-deps:stretch
+        steps:
+          - checkout
+          - setup_remote_docker
+          - run:
+              name: Build Docker image
+              command: docker build -t $IMAGE_NAME:latest .
+      publish-latest:
+        environment:
+          IMAGE_NAME: yusufameri/cah
+        docker:
+          - image: circleci/buildpack-deps:stretch
+        steps:
+          - setup_remote_docker
+          - run:
+              name: Publish Docker Image to Docker Hub
+              command: |
+                echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+                docker push $IMAGE_NAME:latest
+    workflows:
+      version: 2
+      build-master:
+        jobs:
+          - build:
+              filters:
+                branches:
+                  only: cicd
+          - publish-latest:
+              requires:
+                - build
+              filters:
+                branches:
+                  only: cicd

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,22 +1,21 @@
-version: 2.0
+version: 2
 jobs:
- build:
-   # pre-built images: https://circleci.com/docs/2.0/circleci-images/
-   docker:
-     - image: circleci/node:10-browsers
-   steps:
-     - checkout
-     - run:
-         name: The First Step
-         command: |
-           echo 'Hello World!'
-           echo 'This is the delivery pipeline'
-     - run:
-         name: Code Has Arrived
-         command: |
-           ls -al
-           echo '^^^That should look familiar^^^'
-     - run:
-         name: Running in a Unique Container
-         command: |
-           node -v
+  build:
+    environment:
+      IMAGE_NAME: yusufameri/cah
+    docker:
+      - image: circleci/buildpack-deps:stretch
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build Docker image
+          command: docker build -t $IMAGE_NAME:latest .
+workflows:
+  version: 2
+  build-master:
+    jobs:
+      - build:
+          filters:
+            branches:
+              only: cicd

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,39 +1,39 @@
 version: 2
-    jobs:
-      build:
-        environment:
-          IMAGE_NAME: yusufameri/cah
-        docker:
-          - image: circleci/buildpack-deps:stretch
-        steps:
-          - checkout
-          - setup_remote_docker
-          - run:
-              name: Build Docker image
-              command: docker build -t $IMAGE_NAME:latest .
-      publish-latest:
-        environment:
-          IMAGE_NAME: yusufameri/cah
-        docker:
-          - image: circleci/buildpack-deps:stretch
-        steps:
-          - setup_remote_docker
-          - run:
-              name: Publish Docker Image to Docker Hub
-              command: |
-                echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-                docker push $IMAGE_NAME:latest
-    workflows:
-      version: 2
-      build-master:
-        jobs:
-          - build:
-              filters:
-                branches:
-                  only: cicd
-          - publish-latest:
-              requires:
-                - build
-              filters:
-                branches:
-                  only: cicd
+  jobs:
+    build:
+      environment:
+        IMAGE_NAME: yusufameri/cah
+      docker:
+        - image: circleci/buildpack-deps:stretch
+      steps:
+        - checkout
+        - setup_remote_docker
+        - run:
+            name: Build Docker image
+            command: docker build -t $IMAGE_NAME:latest .
+    publish-latest:
+      environment:
+        IMAGE_NAME: yusufameri/cah
+      docker:
+        - image: circleci/buildpack-deps:stretch
+      steps:
+        - setup_remote_docker
+        - run:
+            name: Publish Docker Image to Docker Hub
+            command: |
+              echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+              docker push $IMAGE_NAME:latest
+  workflows:
+    version: 2
+    build-master:
+      jobs:
+        - build:
+            filters:
+              branches:
+                only: cicd
+        - publish-latest:
+            requires:
+              - build
+            filters:
+              branches:
+                only: cicd

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,23 @@ jobs:
           command: |
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
             docker push $IMAGE_NAME:latest
+  publish-tag:
+        executor: docker-publisher
+        steps:
+          - attach_workspace:
+              at: /tmp/workspace
+          - setup_remote_docker
+          - run:
+              name: Load archived Docker image
+              command: docker load -i /tmp/workspace/image.tar
+          - run:
+              name: Publish Docker Image to Docker Hub
+              command: |
+                echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+                IMAGE_TAG=${CIRCLE_TAG/v/''}
+                docker tag $IMAGE_NAME:latest $IMAGE_NAME:$IMAGE_TAG
+                docker push $IMAGE_NAME:latest
+                docker push $IMAGE_NAME:$IMAGE_TAG
 workflows:
   version: 2
   build-master:
@@ -50,3 +67,19 @@ workflows:
           filters:
             branches:
               only: cicd
+    build-tags:
+      jobs:
+        - build:
+            filters:
+              tags:
+                only: /^v.*/
+              branches:
+                ignore: /.*/
+        - publish-tag:
+            requires:
+              - build
+            filters:
+              tags:
+                only: /^v.*/
+              branches:
+                ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,39 +1,39 @@
 version: 2
-  jobs:
-    build:
-      environment:
-        IMAGE_NAME: yusufameri/cah
-      docker:
-        - image: circleci/buildpack-deps:stretch
-      steps:
-        - checkout
-        - setup_remote_docker
-        - run:
-            name: Build Docker image
-            command: docker build -t $IMAGE_NAME:latest .
-    publish-latest:
-      environment:
-        IMAGE_NAME: yusufameri/cah
-      docker:
-        - image: circleci/buildpack-deps:stretch
-      steps:
-        - setup_remote_docker
-        - run:
-            name: Publish Docker Image to Docker Hub
-            command: |
-              echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-              docker push $IMAGE_NAME:latest
-  workflows:
-    version: 2
-    build-master:
-      jobs:
-        - build:
-            filters:
-              branches:
-                only: cicd
-        - publish-latest:
-            requires:
-              - build
-            filters:
-              branches:
-                only: cicd
+jobs:
+  build:
+    environment:
+      IMAGE_NAME: yusufameri/cah
+    docker:
+      - image: circleci/buildpack-deps:stretch
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build Docker image
+          command: docker build -t $IMAGE_NAME:latest .
+  publish-latest:
+    environment:
+      IMAGE_NAME: yusufameri/cah
+    docker:
+      - image: circleci/buildpack-deps:stretch
+    steps:
+      - setup_remote_docker
+      - run:
+          name: Publish Docker Image to Docker Hub
+          command: |
+            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+            docker push $IMAGE_NAME:latest
+workflows:
+  version: 2
+  build-master:
+    jobs:
+      - build:
+          filters:
+            branches:
+              only: cicd
+      - publish-latest:
+          requires:
+            - build
+          filters:
+            branches:
+              only: cicd


### PR DESCRIPTION
# Whats New?
This PR configures CircleCI to automatically create and push a new docker image build (and tag it) for both latest and the CircleCI build num whenever new commits are merged onto master. Basically, we are getting a CI / CD pipeline. Cardiparty.co is currently released on azure as a container with a specific build tag, so pushes to master (i.e. new _latest_ tags) don't update anything on production unless we (I @yusufameri ) update the deployed version manually.